### PR TITLE
Add less frequently used verbs as values

### DIFF
--- a/meetings-en/meeting-01.yml
+++ b/meetings-en/meeting-01.yml
@@ -49,7 +49,7 @@ resolutions:
     message: considering that the international Metre and Kilogram and the national
       Metres and Kilograms fulfil the requirements of the Metre Convention,
   actions:
-  - type: decides
+  - type: sanctions
     date_effective: 1889-09-28
     message: |-
       *sanctions*

--- a/meetings-en/meeting-01.yml
+++ b/meetings-en/meeting-01.yml
@@ -55,11 +55,15 @@ resolutions:
       *sanctions*
 
       [type=A]
-      . As regards international prototypes:
+      . Regarding international prototypes:
 
       .. The Prototype of the metre chosen by the CIPM. This prototype, at the temperature of melting ice, shall henceforth represent the metric unit of length.
       .. The Prototype of the kilogram adopted by the CIPM. This prototype shall henceforth be considered as the unit of mass.
       .. The hydrogen thermometer centigrade scale in terms of which the equations of the prototype Metres have been established.
-      . As regards national prototypes:
+      . Regarding national prototypes:
 
-      ...
+      .. Meters of platinum iridium, the equations of which, with respect to the international Prototype, are contained within the limit of 0.01 millimeter, with a probable error not exceeding ± 0.0002 millimeter.
+      .. Kilograms of platinum iridium, the equations of which are contained within the limit of 1 milligram, with a probable error not exceeding ± 0.005 milligram.
+      
+      . Regarding the equations of the national prototypes:
+      The equations of the national prototypes, as determined at the International Bureau, under the direction of the CIPM, and recorded in the Report of this Committee and on the certificates accompanying these prototypes.

--- a/meetings-en/meeting-03.yml
+++ b/meetings-en/meeting-03.yml
@@ -17,12 +17,12 @@ resolutions:
     message: The Conference
   considerations: []
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: 'declares The unit of volume, for high accuracy determinations, is the
       volume occupied by a mass of 1 kilogram of pure water, at its maximum density
       and at standard atmospheric pressure: this volume is called "litre".'
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: declares . . .
 - dates:
@@ -53,17 +53,17 @@ resolutions:
       current practice still exists on the meaning of the word _weight_, used sometimes
       for _mass_, sometimes for _mechanical force_;"
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: The Conference declares The kilogram is the unit of mass; it is equal
       to the mass of the international prototype of the kilogram;
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: 'The Conference declares The word "weight" denotes a quantity of the
       same nature as a "force": the weight of a body is the product of its mass and
       the acceleration due to gravity; in particular, the standard weight of a body
       is the product of its mass and the standard acceleration due to gravity;'
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: The Conference declares The value adopted in the International Service
       of Weights and Measures for the standard acceleration due to gravity is stem:[980.665

--- a/meetings-en/meeting-08.yml
+++ b/meetings-en/meeting-08.yml
@@ -41,7 +41,7 @@ resolutions:
     message: considérant la déclaration du Président du Comité international des poids
       et mesures approuvant ce Rapport,
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 1933-10-10
     message: autorise le Comité international à faire, à tous les certificats des
       mètres prototypes des coulées Johnson-Matthey et de 1874, une addition donnant
@@ -77,13 +77,13 @@ resolutions:
     message: considérant la déclaration du Président du Comité international des poids
       et mesures approuvant, au nom du Comité, les termes de ce Rapport,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare n'être plus parfaitement conformes à la réalité les équations
       sanctionnées par la Première Conférence générale ; elle annule en conséquence
       les certificats y relatifs en ce qui concerne les équations et en prolonge la
       validité pour le reste,
-  - type: appoints
+  - type: authorizes
     date_effective: 1933-10-10
     message: autorise le Comité international à faire auxdits certificats une addition
       portant la valeur de la longueur à 0° des Mètres n^os^ 1, 8, 14, 15, 17, 18,
@@ -117,7 +117,7 @@ resolutions:
     message: entendu la déclaration du Président du Comité international des poids
       et mesures approuvant ce Rapport, au nom du Comité,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare homologuer le certificat délivré à la date du 30 octobre 1929
       relatif au Mètre n° 7, alliage de 1874.
@@ -150,13 +150,13 @@ resolutions:
     message: entendu la déclaration du Président du Comité international des poids
       et mesures approuvant, au nom du Comité, les termes de ce Rapport,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare n'être plus parfaitement conformes à la réalité les équations
       sanctionnées par la Première Conférence générale ; elle annule en conséquence
       les certificats en ce qui concerne les équations et en prolonge la validité
       pour le reste,
-  - type: appoints
+  - type: authorizes
     date_effective: 1933-10-10
     message: autorise le Comité international à faire auxdits certificats une addition
       portant la valeur de la masse des kilogrammes n° 14 et 15, telle qu'elle résulte
@@ -190,7 +190,7 @@ resolutions:
     message: entendu la déclaration du Président du Comité international des poids
       et mesures approuvant ce rapport, au nom du Comité,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare homologuer le certificat délivré à la date du 20 octobre 1929,
       relatif aux comparaisons effectuées sur le kilogramme n° 41 et donnant son équation,
@@ -248,7 +248,7 @@ resolutions:
       n'ont pas encore terminé les mesures nécessaires pour relier les unités internationales
       aux unités absolues,
   actions:
-  - type: decides
+  - type: sanctions
     date_effective: 1933-10-10
     message: sanctionne le principe de la substitution du Système absolu des unités
       électriques au Système international ;
@@ -302,7 +302,7 @@ resolutions:
     message: ayant entendu l'avis de M. le Président du Comité international des poids
       et mesures,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare qu'elle se considère comme faisant suite à la Conférence de Londres
       de 1908, et qu'en conséquence, elle délègue au Comité international tous pouvoirs
@@ -380,6 +380,6 @@ resolutions:
       à constituer un Comité consultatif de métrologie appliquée auprès du Comité
       international des poids et mesures,
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1933-10-10
     message: charge le Comité international de l'étude de cette question.

--- a/meetings-en/meeting-10.yml
+++ b/meetings-en/meeting-10.yml
@@ -97,7 +97,7 @@ resolutions:
       to believe that this definition of the standard atmosphere was valid only for
       accurate work in thermometry,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1954-10-14
     message: |-
       *declares* that it adopts, for general use, the definition: +

--- a/meetings-en/meeting-11.yml
+++ b/meetings-en/meeting-11.yml
@@ -62,7 +62,7 @@ resolutions:
       les règles générales de la métrologie et les règles particulières à chaque forme
       d'étalon,
   actions:
-  - type: approves
+  - type: endorses
     date_effective: 1960-10-20
     message: entérine l'action déjà engagée par le Comité international des poids
       et mesures dans le domaine des radiations ionisantes, et
@@ -122,7 +122,7 @@ resolutions:
     message: remercie l'Institut du radium de l'Université de Paris d'avoir bien voulu
       confier au Bureau international des poids et mesures la garde de l'Étalon international
       de radium N° 5430, et
-  - type: appoints
+  - type: authorizes
     date_effective: 1960-10-20
     message: autorise le Bureau international à prendre en charge cet Étalon.
 - dates:
@@ -279,7 +279,7 @@ resolutions:
     message: considérant les premières instructions préparées par le Comité international
       des poids et mesures sur la mise en pratique de la nouvelle définition du mètre,
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1960-10-20
     message: charge le Bureau international des poids et mesures de déterminer comme
       par le passé les Prototypes nationaux.
@@ -302,7 +302,7 @@ resolutions:
     date_effective: 1960-10-20
     message: considering the decision taken by the CIPM in 1956,
   actions:
-  - type: decides
+  - type: ratifies
     date_effective: 1960-10-20
     message: |-
       *ratifies* the following definition:
@@ -521,7 +521,7 @@ resolutions:
       règlements établis pour les ressortissants et établissements nationaux français
       ou étrangers se trouvant en France,
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1960-10-20
     message: charge le Comité international des poids et mesures de négocier avec
       le Gouvernement français un accord de siège sur une base non discriminatoire

--- a/meetings-en/meeting-12.yml
+++ b/meetings-en/meeting-12.yml
@@ -95,7 +95,7 @@ resolutions:
     message: lance un appel à tous les États adhérents de la Convention du Mètre de
       faire tout ce qui dépend d'eux pour un travail fructueux du Comité international
       des poids et mesures et du Bureau international, et
-  - type: appoints
+  - type: charges
     date_effective: 1964-10-13
     message: charge le Comité international des poids et mesures de prendre toutes
       les mesures nécessaires à l'expansion ultérieure du Système Métrique et à l'adhésion
@@ -176,7 +176,7 @@ resolutions:
     message: "*considering also* that it is not desirable to wait any longer before
       time measurements in physics are based on atomic or molecular frequency standards,"
   actions:
-  - type: appoints
+  - type: empowers
     date_effective: 1964-10-13
     message: "*empowers* the Comité International des Poids et Mesures to name the
       atomic or molecular frequency standards to be employed for the time being,"
@@ -201,12 +201,12 @@ resolutions:
       CGPM in 1960 and the Recommendation adopted by the Comité International des
       Poids et Mesures in 1961,
   actions:
-  - type: decides
+  - type: abrogates
     date_effective: 1964-10-13
     message: |-
       *abrogates*
        the definition of the litre given in 1901 by the 3rd CGPM,
-  - type: decides
+  - type: declares
     date_effective: 1964-10-13
     message: "*declares* \nthat the word \"litre\" may be employed as a special name
       for the cubic decimetre,"
@@ -233,7 +233,7 @@ resolutions:
     date_effective: 1964-10-13
     message: '*recognizing* that in the Système International d''Unités (SI), the
       unit of this activity is the second to the power of minus one stem:[("s"^(-1))],'
-  - type: acknowledging
+  - type: accepts
     date_effective: 1964-10-13
     message: '*accepts* that the curie be still retained, outside SI, as unit of activity,
       with the value stem:[3.7 * 10^(10) "s"^(-1)]. The symbol for this unit is Ci.'

--- a/meetings-en/meeting-13.yml
+++ b/meetings-en/meeting-13.yml
@@ -374,7 +374,7 @@ resolutions:
       .<| 515 000 francs-or en 1972
 
       |===
-  - type: appoints
+  - type: authorizes
     date_effective: 1967-10-16
     message: autorise que ces sommes supplémentaires puissent être payées en monnaie
       nationale ;

--- a/meetings-en/meeting-14.yml
+++ b/meetings-en/meeting-14.yml
@@ -96,7 +96,7 @@ resolutions:
       continuer, et si possible augmenter, l'aide qu'elles donnent au Bureau international
       de l'heure, pour le bien de la communauté scientifique et technique internationale
       ;"
-  - type: appoints
+  - type: authorizes
     date_effective: 1971-10-08
     message: "*autorise* le Comité international des poids et mesures à conclure avec
       le Bureau international de l'heure les arrangements nécessaires pour la réalisation
@@ -214,7 +214,7 @@ resolutions:
       |
 
       |===
-  - type: appoints
+  - type: authorizes
     date_effective: 1971-10-08
     message: autorise que, sous réserve de la condition ci-après, un pourcentage de
       22 pour cent des contributions annuelles puisse être payé en monnaie nationale,

--- a/meetings-en/meeting-15.yml
+++ b/meetings-en/meeting-15.yml
@@ -26,7 +26,7 @@ resolutions:
       and a reproducibility exceeding those of the krypton 86 radiation of the metre
       definition,
   actions:
-  - type: decides
+  - type: judges
     date_effective: 1975-06-02
     message: judges nevertheless that it is premature to contemplate a change of the
       metre definition,
@@ -151,7 +151,7 @@ resolutions:
     message: "*notes* that this Coordinated Universal Time provides the basis of civil
       time, the use of which is legal in most countries,"
   actions:
-  - type: decides
+  - type: judges
     date_effective: 1975-06-02
     message: "*judges* that this usage can be strongly endorsed."
 - dates:

--- a/meetings-en/meeting-16.yml
+++ b/meetings-en/meeting-16.yml
@@ -258,7 +258,7 @@ resolutions:
       * that following the adherence of the People's Republic of China to the Convention du Metre, the annual budget which serves as the base for the calculation of the budget for the years 1981-1984 is obtained by multiplying the annual budget of the BIPM for the year 1980 voted by the 15th CGPM, by a factor stem:[(100 + x)/100],
 
       where stem:[x] represents the repartition percentage calculated for the People's Republic of China from the United Nations coefficient in force on the 1st January 1980 on applying the procedure adopted by the 11th CGPM,
-  - type: acknowledging
+  - type: accepts
     date_effective: 1979-10-12
     message: accepting without any opposing vote the principle of the proposal of
       the CIPM duly notified in advance to Governments in conformity with Article

--- a/meetings-en/meeting-19.yml
+++ b/meetings-en/meeting-19.yml
@@ -21,7 +21,7 @@ resolutions:
     message: noting that the accuracy of clock comparisons has been greatly improved
       by the use of satellite techniques,
   actions:
-  - type: affirms / reaffirming
+  - type: remarks
     date_effective: 1991-10-03
     message: |-
       remarks that this accuracy

--- a/meetings-en/meeting-20.yml
+++ b/meetings-en/meeting-20.yml
@@ -463,7 +463,7 @@ resolutions:
     degree: unanimous
     message: The 20th Conférence Générale des Poids et Mesures,
   considerations:
-  - type: having / having regard
+  - type: referring
     date_effective: 1995-10-13
     message: "*referring* to cgpm-resolution:en/20/1[Resolution 1]: The need to use
       SI units in studies of Earth resources, the environment, human well-being and

--- a/meetings-en/meeting-26.yml
+++ b/meetings-en/meeting-26.yml
@@ -193,40 +193,40 @@ resolutions:
       "_the SI second as realized on the rotating geoid as the scale unit_" while
       the definition of stem:["TT"] does not refer to the geoid,
   actions:
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: 'states that TAI is a continuous time scale produced by the BIPM based
       on the best realizations of the SI second, and is a realization of stem:["TT"]
       as defined by IAU Resolution B1.9 (2000), '
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: states that in the transformation from the proper time of a clock to
       TAI, the relativistic rate shift is computed with respect to the conventionally
       adopted equipotential stem:[W_(0) = 62 636 856.0 "m"^(2)"s"^(-2)] of the Earth's
       gravity potential, which conforms to the constant stem:[L_(G)] defining the
       rate of stem:["TT"],
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: 'states that as stated in the IAU Resolution A4 (1991), stem:["TT"] -
       TAI = stem:[32.184 "s"] exactly at 1 January 1977, 0h TAI at the geocentre,
       in order to ensure continuity of stem:["TT"] with Ephemeris Time, '
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: 'states that UTC produced by the BIPM, based on TAI, is the only recommended
       time scale for international reference and the basis of civil time in most countries, '
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: 'states that UTC differs from TAI only by an integral number of seconds
       as published by the BIPM, '
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: 'states that users can derive the rotation angle of the Earth by applying
       to UTC the observed or predicted values of UT1 - UTC, as provided by the IERS, '
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: 'states that UTC provides a means to measure time intervals and to disseminate
       the standard of frequency during intervals in which leap seconds do not occur, '
-  - type: affirms / reaffirming
+  - type: states
     date_effective: 2018-11-16
     message: states that traceability to UTC is obtained through local real-time realizations
       "stem:["UTC" (k)]" maintained by laboratories contributing data to the calculation
@@ -423,12 +423,12 @@ resolutions:
       8 adopted by the CGPM at its 23rd meeting (2007)] on financial arrears of Member
       States sets a procedure concerning States who fail to fulfil their financial
       obligations,"
-  - type: noting
+  - type: observing
     date_effective: 2018-11-16
     message: 'observing that paragraphs 6 and 7 of Article 6 of the Annexed Regulations
       foresee that whilst the advantages and prerogatives of Member States are suspended
       for those States in arrears by three years, their contributions remain due, '
-  - type: noting
+  - type: observing
     date_effective: 2018-11-16
     message: observing that historical practice has always been to apply paragraphs
       6 and 7 of Article 6 of the Annexed Regulations,

--- a/meetings-fr/meeting-01.yml
+++ b/meetings-fr/meeting-01.yml
@@ -53,7 +53,7 @@ resolutions:
       et les Kilogrammes nationaux remplissent les conditions exigées par la Convention
       du Mètre ;
   actions:
-  - type: decides
+  - type: sanctions
     date_effective: 1889-09-28
     message: |-
       *sanctionne*

--- a/meetings-fr/meeting-03.yml
+++ b/meetings-fr/meeting-03.yml
@@ -17,7 +17,7 @@ resolutions:
     message: Unanimous
   considerations: []
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: |-
       La Conférence déclare :
@@ -38,11 +38,11 @@ resolutions:
     degree: unanimous
     message: Unanimous
   considerations:
-  - type: having / having regard
+  - type: taking into account
     date_effective: 1901-10-22
     message: "*Vu* la décision du Comité international des poids et mesures du 15
       octobre 1887, par laquelle le kilogramme a été défini comme unité de masse ;"
-  - type: having / having regard
+  - type: taking into account
     date_effective: 1901-10-22
     message: "*Vu* la décision contenue dans la formule de sanction des prototypes
       du Système métrique, acceptée à l'unanimité par la Conférence générale des poids
@@ -53,7 +53,7 @@ resolutions:
       dans l'usage courant sur la signification du terme _poids_, employé tantôt dans
       le sens du terme _masse_, tantôt dans le sens du terme _effort mécanique_ ;"
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1901-10-22
     message: |-
       *La Conférence déclare :*

--- a/meetings-fr/meeting-08.yml
+++ b/meetings-fr/meeting-08.yml
@@ -41,7 +41,7 @@ resolutions:
     message: considérant la déclaration du Président du Comité international des poids
       et mesures approuvant ce Rapport,
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 1933-10-10
     message: autorise le Comité international à faire, à tous les certificats des
       mètres prototypes des coulées Johnson-Matthey et de 1874, une addition donnant
@@ -77,13 +77,13 @@ resolutions:
     message: considérant la déclaration du Président du Comité international des poids
       et mesures approuvant, au nom du Comité, les termes de ce Rapport,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare n'être plus parfaitement conformes à la réalité les équations
       sanctionnées par la Première Conférence générale ; elle annule en conséquence
       les certificats y relatifs en ce qui concerne les équations et en prolonge la
       validité pour le reste,
-  - type: appoints
+  - type: authorizes
     date_effective: 1933-10-10
     message: autorise le Comité international à faire auxdits certificats une addition
       portant la valeur de la longueur à 0° des Mètres n^os^ 1, 8, 14, 15, 17, 18,
@@ -150,13 +150,13 @@ resolutions:
     message: entendu la déclaration du Président du Comité international des poids
       et mesures approuvant, au nom du Comité, les termes de ce Rapport,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare n'être plus parfaitement conformes à la réalité les équations
       sanctionnées par la Première Conférence générale ; elle annule en conséquence
       les certificats en ce qui concerne les équations et en prolonge la validité
       pour le reste,
-  - type: appoints
+  - type: authorizes
     date_effective: 1933-10-10
     message: autorise le Comité international à faire auxdits certificats une addition
       portant la valeur de la masse des kilogrammes n° 14 et 15, telle qu'elle résulte
@@ -190,7 +190,7 @@ resolutions:
     message: entendu la déclaration du Président du Comité international des poids
       et mesures approuvant ce rapport, au nom du Comité,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare homologuer le certificat délivré à la date du 20 octobre 1929,
       relatif aux comparaisons effectuées sur le kilogramme n° 41 et donnant son équation,
@@ -248,7 +248,7 @@ resolutions:
       n'ont pas encore terminé les mesures nécessaires pour relier les unités internationales
       aux unités absolues,
   actions:
-  - type: decides
+  - type: sanctions
     date_effective: 1933-10-10
     message: sanctionne le principe de la substitution du Système absolu des unités
       électriques au Système international ;
@@ -302,7 +302,7 @@ resolutions:
     message: ayant entendu l'avis de M. le Président du Comité international des poids
       et mesures,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1933-10-10
     message: déclare qu'elle se considère comme faisant suite à la Conférence de Londres
       de 1908, et qu'en conséquence, elle délègue au Comité international tous pouvoirs
@@ -380,6 +380,6 @@ resolutions:
       à constituer un Comité consultatif de métrologie appliquée auprès du Comité
       international des poids et mesures,
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1933-10-10
     message: charge le Comité international de l'étude de cette question.

--- a/meetings-fr/meeting-09.yml
+++ b/meetings-fr/meeting-09.yml
@@ -195,7 +195,7 @@ resolutions:
       analogue, accompagnée d'un projet destiné à servir de base de discussion pour
       l'établissement d'une réglementation complète des unités de mesure ;
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1948-10-21
     message: |-
       *charge* le Comité international :
@@ -237,17 +237,17 @@ resolutions:
       stem:[\"°K\"] .<| lux .<| stem:[\"lx\"]\n.<| calorie .<| stem:[\"cal\"] .<|
       lumen .<| stem:[\"lm\"]\n.<| stem:[\"bar\"] .<| stem:[\"bar\"] .<| stilb .<|
       stem:[\"sb\"]\n.<| heure .<| stem:[\"h\"] .<|   .<|  \n\n|==="
-  - type: affirms / reaffirming
+  - type: notes
     date_effective: 1948-10-21
     message: Remarques Les symboles dont les unités sont précédées d'un point sont
       ceux qui avaient déjà été antérieurement adoptés par une décision du Comité
       international.
-  - type: affirms / reaffirming
+  - type: notes
     date_effective: 1948-10-21
     message: Remarques L'unité de volume stère, employée dans le mesurage des bois,
       aura pour symbole « st » et non plus « stem:["s"] », qui lui avait été précédemment
       affecté par le Comité international.
-  - type: affirms / reaffirming
+  - type: notes
     date_effective: 1948-10-21
     message: Remarques S'il s'agit, non d'une température, mais d'un intervalle ou
       d'une différence de température, le mot « degré » doit être écrit en toutes

--- a/meetings-fr/meeting-10.yml
+++ b/meetings-fr/meeting-10.yml
@@ -95,7 +95,7 @@ resolutions:
       l'atmosphère normale était limitée aux besoins de la thermométrie de précision,
   considerations: []
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1954-10-14
     message: |-
       *déclare* qu'elle adopte, pour tous les usages, la définition : +

--- a/meetings-fr/meeting-11.yml
+++ b/meetings-fr/meeting-11.yml
@@ -62,7 +62,7 @@ resolutions:
       les règles générales de la métrologie et les règles particulières à chaque forme
       d'étalon,
   actions:
-  - type: approves
+  - type: endorses
     date_effective: 1960-10-20
     message: entérine l'action déjà engagée par le Comité international des poids
       et mesures dans le domaine des radiations ionisantes, et
@@ -122,7 +122,7 @@ resolutions:
     message: remercie l'Institut du radium de l'Université de Paris d'avoir bien voulu
       confier au Bureau international des poids et mesures la garde de l'Étalon international
       de radium N° 5430, et
-  - type: appoints
+  - type: authorizes
     date_effective: 1960-10-20
     message: autorise le Bureau international à prendre en charge cet Étalon.
 - dates:
@@ -281,7 +281,7 @@ resolutions:
     message: considérant les premières instructions préparées par le Comité international
       des poids et mesures sur la mise en pratique de la nouvelle définition du mètre,
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1960-10-20
     message: charge le Bureau international des poids et mesures de déterminer comme
       par le passé les Prototypes nationaux.
@@ -306,7 +306,7 @@ resolutions:
     message: considérant la décision prise par le Comité international des poids et
       mesures dans sa session de 1956,
   actions:
-  - type: decides
+  - type: ratifies
     date_effective: 1960-10-20
     message: |-
       *ratifie* la définition suivante :
@@ -522,7 +522,7 @@ resolutions:
       règlements établis pour les ressortissants et établissements nationaux français
       ou étrangers se trouvant en France,
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1960-10-20
     message: charge le Comité international des poids et mesures de négocier avec
       le Gouvernement français un accord de siège sur une base non discriminatoire

--- a/meetings-fr/meeting-12.yml
+++ b/meetings-fr/meeting-12.yml
@@ -95,7 +95,7 @@ resolutions:
     message: lance un appel à tous les États adhérents de la Convention du Mètre de
       faire tout ce qui dépend d'eux pour un travail fructueux du Comité international
       des poids et mesures et du Bureau international, et
-  - type: appoints
+  - type: charges
     date_effective: 1964-10-13
     message: charge le Comité international des poids et mesures de prendre toutes
       les mesures nécessaires à l'expansion ultérieure du Système Métrique et à l'adhésion
@@ -178,7 +178,7 @@ resolutions:
       les mesures physiques de temps sur des étalons atomiques ou moléculaires de
       fréquence,"
   actions:
-  - type: appoints
+  - type: empowers
     date_effective: 1964-10-13
     message: "*habilite* le Comité international des poids et mesures à désigner les
       étalons atomiques ou moléculaires de fréquence à employer temporairement,"
@@ -203,12 +203,12 @@ resolutions:
       Onzième Conférence générale en 1960 et la Recommandation adoptée par le Comité
       international des poids et mesures à sa session de 1961,
   actions:
-  - type: decides
+  - type: abrogates
     date_effective: 1964-10-13
     message: |-
       *abroge*
        la définition du litre donnée en 1901 par la Troisième Conférence générale des poids et mesures,
-  - type: decides
+  - type: declares
     date_effective: 1964-10-13
     message: "*déclare* \nque le mot « litre » peut être utilisé comme un nom spécial
       donné au décimètre cube,"

--- a/meetings-fr/meeting-13.yml
+++ b/meetings-fr/meeting-13.yml
@@ -377,7 +377,7 @@ resolutions:
       .<| 515 000 francs-or en 1972
 
       |===
-  - type: appoints
+  - type: authorizes
     date_effective: 1967-10-16
     message: autorise que ces sommes supplémentaires puissent être payées en monnaie
       nationale ;

--- a/meetings-fr/meeting-14.yml
+++ b/meetings-fr/meeting-14.yml
@@ -93,7 +93,7 @@ resolutions:
       continuer, et si possible augmenter, l'aide qu'elles donnent au Bureau international
       de l'heure, pour le bien de la communauté scientifique et technique internationale
       ;"
-  - type: appoints
+  - type: authorizes
     date_effective: 1971-10-08
     message: "*autorise* le Comité international des poids et mesures à conclure avec
       le Bureau international de l'heure les arrangements nécessaires pour la réalisation
@@ -211,7 +211,7 @@ resolutions:
       |
 
       |===
-  - type: appoints
+  - type: authorizes
     date_effective: 1971-10-08
     message: autorise que, sous réserve de la condition ci-après, un pourcentage de
       22 pour cent des contributions annuelles puisse être payé en monnaie nationale,

--- a/meetings-fr/meeting-15.yml
+++ b/meetings-fr/meeting-15.yml
@@ -95,7 +95,7 @@ resolutions:
     message: "*demande* au Bureau international des poids et mesures et aux laboratoires
       nationaux de poursuivre des études visant à améliorer la précision des comparaisons
       d'étalons de masse,"
-  - type: appoints
+  - type: charges
     date_effective: 1975-06-02
     message: et charge le Bureau international des poids et mesures d'organiser ensuite
       une vérification des étalons nationaux de masse.

--- a/meetings-fr/meeting-16.yml
+++ b/meetings-fr/meeting-16.yml
@@ -147,7 +147,7 @@ resolutions:
     message: La Seizième Conférence générale des poids et mesures,
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 1979-10-12
     message: charge le Comité international des poids et mesures d'organiser des comparaisons
       internationales afin que soit contrôlée l'uniformité des résultats des mesures

--- a/meetings-fr/meeting-18.yml
+++ b/meetings-fr/meeting-18.yml
@@ -219,7 +219,7 @@ resolutions:
       et de la tension par le courant dans l'effet Hall quantique à poursuivre activement
       ces travaux et à communiquer sans délai leurs résultats au Comité international
       des poids et mesures et,
-  - type: appoints
+  - type: charges
     date_effective: 1987-10-15
     message: charge le Comité international des poids et mesures de recommander, dès
       qu'il le jugera possible, une valeur de chacun de ces quotients et une date

--- a/meetings-fr/meeting-22.yml
+++ b/meetings-fr/meeting-22.yml
@@ -546,7 +546,7 @@ resolutions:
       points, ni par des virgules », comme le recommande la cgpm-resolution:fr/9/7[Résolution
       7] de la 9^e^ Conférence générale de 1948.
   actions:
-  - type: decides
+  - type: declares
     date_effective: 2003-10-17
     message: déclare que le symbole du séparateur décimal pourra être le point sur
       la ligne ou la virgule sur la ligne,

--- a/meetings-fr/meeting-26.yml
+++ b/meetings-fr/meeting-26.yml
@@ -192,43 +192,43 @@ resolutions:
       en rotation » alors que la définition de stem:["TT"] ne fait pas référence au
       géoïde,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que le TAI est une échelle de temps continue produite par le
       BIPM à partir des meilleures réalisations de la seconde du SI et que c'est une
       réalisation de stem:["TT"] comme défini dans la Résolution B1.9 (2000) de l'UAI,
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que pour la conversion du temps propre d'une horloge en TAI,
       le décalage relativiste de fréquence est calculé par rapport à la surface équipotentielle
       stem:[W_(0) = 62 636 856","0 "m"^(2) * "s"^(-2)] du potentiel de pesanteur de
       la Terre, adoptée de façon conventionnelle, en conformité avec la constante
       LG définissant la marche de stem:["TT"],
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que tel qu'indiqué dans la Résolution A4 (1991) de l'UAI, stem:["TT"]
       - TAI est égal à stem:[32","184 "s"] exactement au 1^er^ janvier 1977, 0h TAI
       au géocentre, pour assurer une continuité de stem:["TT"] avec le temps des éphémérides,
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que l'UTC produit par le BIPM, fondé sur le TAI, est l'unique
       échelle de temps recommandée comme référence internationale et qu'il est à la
       base du temps civil dans la plupart des pays,
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que l'UTC diffère du TAI seulement par un nombre entier de secondes,
       tel que publié par le BIPM,
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que les utilisateurs peuvent dériver l'angle de rotation de la
       Terre en appliquant à l'UTC les valeurs observées ou prédites d'UT1 - UTC, telles
       que fournies par l'IERS,
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que l'UTC fournit un moyen de mesurer les intervalles de temps
       et de disséminer l'étalon de fréquence pendant les intervalles qui ne comprennent
       pas de secondes intercalaires,
-  - type: decides
+  - type: declares
     date_effective: 2018-11-16
     message: déclare que la traçabilité à l'UTC est obtenue par l'intermédiaire des
       réalisations locales en temps réel maintenues par les laboratoires participant
@@ -436,7 +436,7 @@ resolutions:
       7. Les avantages et prérogatives conférés par l'adhésion à la Convention du Mètre sont suspendus à l'égard des États déficitaires de trois années. +
       8. Après trois nouvelles années, l'État déficitaire est exclu de la Convention, et le calcul des contributions est rétabli conformément aux dispositions de l'article 20 du présent Règlement._ » +
       * la Résolution 8 adoptée par la CGPM à sa 23^e^réunion (2007) sur les contributions arriérées des États Membres, qui établit une procédure concernant les États qui ne respectent pas leurs obligations financières
-  - type: noting
+  - type: observing
     date_effective: 2018-11-16
     message: |-
       *observant* que
@@ -471,7 +471,7 @@ resolutions:
   - type: considering
     date_effective: 2018-11-16
     message: |-
-      *considérant*que
+      *considérant* que
 
       * la clarté de la procédure et le traitement équitable des États Membres sont des questions de bonne gouvernance et sont bénéfiques à toutes les parties,
       * le Comité international des poids et mesures (CIPM), en tant qu'organe de surveillance permanent du BIPM, pourrait appliquer l'article 6 alinéa 8 du Règlement annexé en temps opportun,
@@ -479,14 +479,14 @@ resolutions:
   - type: decides
     date_effective: 2018-11-16
     message: |-
-      *décide*que
+      *décide* que
 
       * le CIPM appliquera l'article 6 alinéa 8 du Règlement annexé,
       * le CIPM traitera des cas où la pratique historique a conduit à l'accumulation d'arriérés,
   - type: confirms
     date_effective: 2018-11-16
     message: |-
-      *confirme*que
+      *confirme* que
 
       * le CIPM notifiera toute exclusion au Ministère français de l'Europe et des Affaires étrangères, qui informera à son tour l'État exclu ainsi que l'ensemble des États Membres,
       * un État Membre exclu ne peut de nouveau accéder à la Convention du Mètre que si le reliquat de ses contributions arriérées a été acquitté,


### PR DESCRIPTION
As requested in https://github.com/metanorma/cipm-resolutions/issues/4, less frequently used verbs are added as values in CGPM .yml files.

Sanctions are also added for 1st meeting, as requested in https://github.com/metanorma/cgpm-resolutions/issues/4.